### PR TITLE
[TASK] 랜덤 직업 할당 구현

### DIFF
--- a/packages/server/constants/job.ts
+++ b/packages/server/constants/job.ts
@@ -1,0 +1,26 @@
+const createJobCountArr = ({ mafia = 0, citizen = 0, police = 0, doctor = 0 }): string[] => [
+  ...new Array(mafia).fill('mafia'),
+  ...new Array(citizen).fill('citizen'),
+  ...new Array(police).fill('police'),
+  ...new Array(doctor).fill('doctor'),
+];
+
+const JOB_COUNT: object[] = [
+  {},
+  {},
+  {},
+  {},
+  { mafia: 1, citizen: 4 },
+  { mafia: 2, citizen: 4 },
+  { mafia: 2, citizen: 5 },
+  { mafia: 2, citizen: 6 },
+  { mafia: 3, citizen: 5 },
+  { mafia: 3, citizen: 6 },
+  { mafia: 3, citizen: 7 },
+  { mafia: 3, citizen: 8 },
+  { mafia: 4, citizen: 8 },
+];
+
+const JOB_ARR: string[][] = JOB_COUNT.map((cnt) => createJobCountArr(cnt));
+
+export { JOB_COUNT, JOB_ARR };

--- a/packages/server/sockets/game.ts
+++ b/packages/server/sockets/game.ts
@@ -2,6 +2,7 @@ import { GAME_OVER, PUBLISH_VOTE, TIMER, TURN_CHANGE, VOTE } from 'domain/consta
 import { GameResult, Job } from 'domain/types/game';
 import { RoomVote, Vote } from 'domain/types/vote';
 import { Namespace, Socket } from 'socket.io';
+import { JOB_ARR } from '../constants/job';
 import { canVote, startVoteTime } from './vote';
 
 interface ChannelVote {
@@ -45,6 +46,16 @@ const getGameResult = (dashBoard: DashBoard, jobAssignment: Job[]): GameResult[]
     return jobAssignment.map((el) => ({ ...el, result: el.job === 'citizen' }));
   }
   return jobAssignment.map((el) => ({ ...el, result: el.job === 'mafia' }));
+};
+
+const assignJobs = () => {
+  const shuffle = (arr: string[]) => arr.sort(() => Math.random() - 0.5);
+
+  const mixedArr = shuffle([]);
+  const jobs = JOB_ARR[mixedArr.length];
+
+  if (jobs.length <= 0) return false;
+  return mixedArr.map((username, idx) => ({ [username]: jobs[idx] }));
 };
 
 const gameSocketInit = (namespace: Namespace, socket: Socket, roomId: string): void => {


### PR DESCRIPTION
## 작업 목록
- [x] 랜덤 직업 할당 논리 구현
- [ ] server 리팩토링
- [ ] 내 직업 클라이언트에 통신
<br/><br/>

## 설명

## Issue traker

- task issues: Resolves #
- considering issues: #
