### PR TITLE
[TASK] 방마다 입장 user 정보를 저장

### DIFF
--- a/packages/client/src/hooks/useRoom.ts
+++ b/packages/client/src/hooks/useRoom.ts
@@ -6,6 +6,9 @@ const useRoom = (socketRef: any) => {
   const [waitingUserList, setWaitingUserList] = useState<WaitingInfo[]>([]);
 
   useEffect(() => {
+    socketRef.current?.on('join', (data: WaitingInfo[]) => {
+      setWaitingUserList(data);
+    });
     socketRef.current?.on(PUBLISH_READY, updateWaitingUserList);
 
     return () => {
@@ -26,7 +29,7 @@ const useRoom = (socketRef: any) => {
 
   const sendGameStart = () => socketRef.current?.emit(GAME_START);
 
-  return { waitingUserList, setWaitingUserList, sendReady, sendGameStart };
+  return { waitingUserList, sendReady, sendGameStart };
 };
 
 export default useRoom;

--- a/packages/client/src/hooks/useRoom.ts
+++ b/packages/client/src/hooks/useRoom.ts
@@ -3,20 +3,7 @@ import { WaitingInfo } from '@mafia/domain/types/user';
 import { useEffect, useState } from 'react';
 
 const useRoom = (socketRef: any) => {
-  const [waitingUserList, setWaitingUserList] = useState<WaitingInfo[]>([
-    { userName: 'user1', isHost: false, isReady: true },
-    { userName: 'user2', isHost: false, isReady: true },
-    { userName: 'user3', isHost: false, isReady: true },
-    { userName: 'user4', isHost: false, isReady: true },
-    { userName: 'user5', isHost: false, isReady: true },
-    { userName: 'binimini', isHost: true, isReady: true },
-    { userName: 'user7', isHost: false, isReady: true },
-    { userName: 'user8', isHost: false, isReady: true },
-    { userName: 'user9', isHost: false, isReady: true },
-    { userName: 'user10', isHost: false, isReady: true },
-    { userName: 'user11', isHost: false, isReady: true },
-    { userName: 'user12', isHost: false, isReady: true },
-  ]);
+  const [waitingUserList, setWaitingUserList] = useState<WaitingInfo[]>([]);
 
   useEffect(() => {
     socketRef.current?.on(PUBLISH_READY, updateWaitingUserList);
@@ -39,7 +26,7 @@ const useRoom = (socketRef: any) => {
 
   const sendGameStart = () => socketRef.current?.emit(GAME_START);
 
-  return { waitingUserList, sendReady, sendGameStart };
+  return { waitingUserList, setWaitingUserList, sendReady, sendGameStart };
 };
 
 export default useRoom;

--- a/packages/client/src/hooks/useRoom.ts
+++ b/packages/client/src/hooks/useRoom.ts
@@ -13,6 +13,7 @@ const useRoom = (socketRef: any) => {
 
     return () => {
       socketRef.current?.off(PUBLISH_READY);
+      socketRef.current?.off('join');
     };
   }, [socketRef.current]);
 

--- a/packages/client/src/hooks/useSocket.ts
+++ b/packages/client/src/hooks/useSocket.ts
@@ -1,12 +1,15 @@
+import { useUserInfo } from '@src/contexts/userInfo';
 import { useEffect, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
 
 const useSocket = (roomId: string) => {
   const socketRef = useRef<Socket>();
   const SOCKET_URL: string = process.env.REACT_APP_SOCKET_URL || 'localhost:5001/';
+  const { userInfo } = useUserInfo();
 
   useEffect(() => {
     socketRef.current = io(SOCKET_URL + roomId);
+    socketRef.current.emit('join', userInfo?.userName);
 
     return () => {
       socketRef.current!.disconnect();

--- a/packages/client/src/pages/Waiting/index.tsx
+++ b/packages/client/src/pages/Waiting/index.tsx
@@ -9,8 +9,6 @@ import useSocket from '@hooks/useSocket';
 import useRoom from '@hooks/useRoom';
 import { useUserInfo } from '@src/contexts/userInfo';
 import { DefaultButton, ButtonSizeList, ButtonThemeList } from '@components/Button';
-import { useEffect } from 'react';
-import { WaitingInfo } from '@mafia/domain/types/user';
 
 interface locationType {
   roomInfo: RoomInfo;
@@ -20,7 +18,7 @@ const Waiting = () => {
   const location = useLocation<locationType>();
   const { roomId } = location.state.roomInfo;
   const { socketRef } = useSocket(roomId);
-  const { waitingUserList, setWaitingUserList, sendReady, sendGameStart } = useRoom(socketRef);
+  const { waitingUserList, sendReady, sendGameStart } = useRoom(socketRef);
   const { userInfo } = useUserInfo();
   const isHost =
     waitingUserList.filter(({ userName }) => userName === userInfo?.userName)[0]?.isHost ?? false;
@@ -30,11 +28,7 @@ const Waiting = () => {
 
     sendReady({ userName: me.userName, isReady: !me.isReady, isHost: me.isHost });
   };
-  useEffect(() => {
-    socketRef.current?.on('join', (data: WaitingInfo[]) => {
-      setWaitingUserList(data);
-    });
-  }, [socketRef]);
+
   // TODO: socket을 useContext로 관리, 여기서 할당해주기!
 
   return (

--- a/packages/client/src/pages/Waiting/index.tsx
+++ b/packages/client/src/pages/Waiting/index.tsx
@@ -9,6 +9,8 @@ import useSocket from '@hooks/useSocket';
 import useRoom from '@hooks/useRoom';
 import { useUserInfo } from '@src/contexts/userInfo';
 import { DefaultButton, ButtonSizeList, ButtonThemeList } from '@components/Button';
+import { useEffect } from 'react';
+import { WaitingInfo } from '@mafia/domain/types/user';
 
 interface locationType {
   roomInfo: RoomInfo;
@@ -18,7 +20,7 @@ const Waiting = () => {
   const location = useLocation<locationType>();
   const { roomId } = location.state.roomInfo;
   const { socketRef } = useSocket(roomId);
-  const { waitingUserList, sendReady, sendGameStart } = useRoom(socketRef);
+  const { waitingUserList, setWaitingUserList, sendReady, sendGameStart } = useRoom(socketRef);
   const { userInfo } = useUserInfo();
   const isHost =
     waitingUserList.filter(({ userName }) => userName === userInfo?.userName)[0]?.isHost ?? false;
@@ -28,6 +30,11 @@ const Waiting = () => {
 
     sendReady({ userName: me.userName, isReady: !me.isReady, isHost: me.isHost });
   };
+  useEffect(() => {
+    socketRef.current?.on('join', (data: WaitingInfo[]) => {
+      setWaitingUserList(data);
+    });
+  }, [socketRef]);
   // TODO: socket을 useContext로 관리, 여기서 할당해주기!
 
   return (

--- a/packages/domain/types/user.ts
+++ b/packages/domain/types/user.ts
@@ -8,7 +8,7 @@ export interface PlayerInfo {
   isReady: boolean; // false (방장은 true)
   isHost: boolean; // false (방장만 true)
   isDead: boolean; // false
-  job?: string;
+  job: string;
   voteFrom: string[];
 }
 

--- a/packages/server/sockets/index.ts
+++ b/packages/server/sockets/index.ts
@@ -25,6 +25,7 @@ const socketInit = (namespace: Namespace): void => {
         isHost,
         isDead: false,
         voteFrom: [],
+        job: '',
       };
       roomStore[roomId] = roomStore[roomId] ?? [];
       roomStore[roomId].push(newUser);

--- a/packages/server/sockets/index.ts
+++ b/packages/server/sockets/index.ts
@@ -13,10 +13,16 @@ const socketInit = (namespace: Namespace): void => {
   namespace.on('connection', (socket: Socket): void => {
     const { nsp } = socket;
     const { name: roomId } = nsp;
-    if (!roomId) return;
+
+    if (!roomId) {
+      return;
+    }
+    if (!roomStore[roomId]) {
+      roomStore[roomId] = [];
+    }
 
     socket.on('join', (userName: string) => {
-      const isHost: boolean = !roomStore[roomId] || roomStore[roomId].length === 1;
+      const isHost: boolean = roomStore[roomId].length === 0;
       const isReady: boolean = isHost;
       const newUser: PlayerInfo = {
         userName,
@@ -27,7 +33,7 @@ const socketInit = (namespace: Namespace): void => {
         voteFrom: [],
         job: '',
       };
-      roomStore[roomId] = roomStore[roomId] ?? [];
+
       roomStore[roomId].push(newUser);
 
       socket.emit('join', roomStore[roomId]);
@@ -38,6 +44,7 @@ const socketInit = (namespace: Namespace): void => {
     });
 
     chatSocketInit(nsp, socket);
+
     gameSocketInit(nsp, socket, roomId, roomStore[roomId]);
   });
 };

--- a/packages/server/sockets/index.ts
+++ b/packages/server/sockets/index.ts
@@ -39,8 +39,6 @@ const socketInit = (namespace: Namespace): void => {
 
     chatSocketInit(nsp, socket);
     gameSocketInit(nsp, socket, roomId, roomStore[roomId]);
-
-    socket.on('disconnect', (): void => {});
   });
 };
 

--- a/packages/server/sockets/index.ts
+++ b/packages/server/sockets/index.ts
@@ -14,10 +14,28 @@ const socketInit = (namespace: Namespace): void => {
     const { nsp } = socket;
     const { name: roomId } = nsp;
     if (!roomId) return;
-    roomStore[roomId] = [];
+
+    socket.on('join', (userName: string) => {
+      const isHost: boolean = !roomStore[roomId] || roomStore[roomId].length === 1;
+      const isReady: boolean = isHost;
+      const newUser: PlayerInfo = {
+        userName,
+        socketId: socket.id,
+        isReady,
+        isHost,
+        isDead: false,
+        voteFrom: [],
+      };
+      if (!roomStore[roomId]) {
+        roomStore[roomId] = [newUser];
+      } else {
+        roomStore[roomId].push(newUser);
+      }
+
+      socket.emit('join', roomStore[roomId]);
+    });
 
     chatSocketInit(nsp, socket);
-    // const gameInfo[roomId]  = jobAssign(roomStore[roomId])
     gameSocketInit(nsp, socket, roomId, roomStore[roomId]);
 
     socket.on('disconnect', (): void => {});

--- a/packages/server/sockets/index.ts
+++ b/packages/server/sockets/index.ts
@@ -35,6 +35,10 @@ const socketInit = (namespace: Namespace): void => {
       socket.emit('join', roomStore[roomId]);
     });
 
+    socket.on('disconnect', () => {
+      roomStore[roomId] = roomStore[roomId]?.filter((user) => user.socketId !== socket.id);
+    });
+
     chatSocketInit(nsp, socket);
     gameSocketInit(nsp, socket, roomId, roomStore[roomId]);
 

--- a/packages/server/sockets/index.ts
+++ b/packages/server/sockets/index.ts
@@ -26,11 +26,8 @@ const socketInit = (namespace: Namespace): void => {
         isDead: false,
         voteFrom: [],
       };
-      if (!roomStore[roomId]) {
-        roomStore[roomId] = [newUser];
-      } else {
-        roomStore[roomId].push(newUser);
-      }
+      roomStore[roomId] = roomStore[roomId] ?? [];
+      roomStore[roomId].push(newUser);
 
       socket.emit('join', roomStore[roomId]);
     });


### PR DESCRIPTION
## 작업 목록

- [x] 방마다 user 정보를 저장하는 roomStore 생성
- [x] user가 소켓에 연결될 때 마다 해당 방 배열에 user 정보 추가
- [x] client에게 해당 방에 있는 모든 user 정보 뿌려줌
- [x] client는 socket으로 받는 user들 정보로 waiting page 그려줌  <br/><br/>

## Issue traker 

- task issues: Resolves #
- considering issues: #
