### PR TITLE
[TASK] 사망시 투표 및 채팅 비활성화

### DIFF
--- a/packages/client/.eslintrc.json
+++ b/packages/client/.eslintrc.json
@@ -45,6 +45,7 @@
           ["@utils", "./src/utils"],
           ["@hooks", "./src/hooks"],
           ["@pages", "./src/pages"],
+          ["@contexts", "./src/contexts"],
           ["@constants", "./src/constants"],
           ["@containers", "./src/containers"],
           ["@components", "./src/components"]

--- a/packages/client/src/containers/ChatContainer.tsx
+++ b/packages/client/src/containers/ChatContainer.tsx
@@ -1,13 +1,14 @@
 import React, { FC, useCallback, useState, useRef, useEffect } from 'react';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
+
 import { Message } from '@mafia/domain/types/chat';
-import { ChatMsg, StoryMsg } from '@components/Message';
+import { Story } from '@src/types';
+import { useUserInfo } from '@src/contexts/userInfo';
 import { SendIcon } from '@components/Icon';
+import { ChatMsg, StoryMsg } from '@components/Message';
 import { IconButton, ButtonSizeList, ButtonThemeList } from '@components/Button';
 import { primaryLight, primaryDark, white, titleActive } from '@constants/index';
-import { useUserInfo } from '@src/contexts/userInfo';
-import { Story } from '@src/types';
 
 interface PropType {
   chatList: (Message | Story)[];
@@ -26,7 +27,6 @@ const ChatContainer: FC<PropType> = ({ chatList, sendChat, sendNightChat, isNigh
   const { userInfo } = useUserInfo();
 
   const canNightChat = () => true; // 밤에 채팅 보낼 수 있는 직업인지 확인
-
   const sendMessage = useCallback(() => {
     if (isNight && !canNightChat()) return;
 

--- a/packages/client/src/containers/LeftSideContainer.tsx
+++ b/packages/client/src/containers/LeftSideContainer.tsx
@@ -34,7 +34,11 @@ const LeftSideContainer: FC<PropType> = ({
       ({ userName: playerName }) => playerName === userInfo?.userName,
     );
     if (!myState || myState.isDead) return;
-    isNight ? emitAbility(userName) : voteUser(userName);
+    if (isNight) {
+      emitAbility(userName);
+    } else {
+      voteUser(userName);
+    }
   };
 
   return (

--- a/packages/client/src/containers/LeftSideContainer.tsx
+++ b/packages/client/src/containers/LeftSideContainer.tsx
@@ -29,6 +29,14 @@ const LeftSideContainer: FC<PropType> = ({
   timer,
 }) => {
   const { userInfo } = useUserInfo();
+  const handleClick = (userName: string) => {
+    const myState = playerStateList.find(
+      ({ userName: playerName }) => playerName === userInfo?.userName,
+    );
+    if (!myState || myState.isDead) return;
+    isNight ? emitAbility(userName) : voteUser(userName);
+  };
+
   return (
     <div css={leftSideContainerStyle}>
       <div css={Style}>
@@ -74,7 +82,7 @@ const LeftSideContainer: FC<PropType> = ({
               (pick) => pick.mafia !== userInfo?.userName && pick.victim === userName,
             )}
             isDead={playerStateList.find((player) => player.userName === userName)?.isDead || false}
-            onClick={isNight ? emitAbility : voteUser}
+            onClick={handleClick}
           />
         ))}
       </div>

--- a/packages/client/src/pages/Game/index.tsx
+++ b/packages/client/src/pages/Game/index.tsx
@@ -1,22 +1,24 @@
+import { useEffect, useState } from 'react';
+import { ToastContainer, toast } from 'react-toastify';
+import { useLocation, useHistory } from 'react-router-dom';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import useTimer from '@src/hooks/useTimer';
+
+import { PlayerState } from '@mafia/domain/types/game';
+import { User } from '@mafia/domain/types/user';
+import { primaryDark, primaryLight, titleActive, white } from '@src/constants';
+import { PlayerInfo, Memo } from '@src/types';
+import { useUserInfo } from '@contexts/userInfo';
+import useGame from '@hooks/useGame';
+import useTimer from '@hooks/useTimer';
 import useVote from '@hooks/useVote';
 import useChat from '@hooks/useChat';
-import useAbility from '@src/hooks/useAbility';
-import { primaryDark, primaryLight, titleActive, white } from '@constants/index';
-import ChatContainer from '@containers/ChatContainer';
+import useAbility from '@hooks/useAbility';
+import usePreventLeave from '@hooks/usePreventLeave';
 import LeftSideContainer from '@containers/LeftSideContainer';
+import ChatContainer from '@containers/ChatContainer';
 import RightSideContainer from '@containers/RightSideContainer';
-import { useEffect, useState } from 'react';
-import useGame from '@src/hooks/useGame';
-import { PlayerState } from '@mafia/domain/types/game';
-import { useLocation, useHistory } from 'react-router-dom';
-import { useUserInfo } from '@src/contexts/userInfo';
-import { PlayerInfo, Memo } from '@src/types';
-import { User } from '@mafia/domain/types/user';
-import usePreventLeave from '@src/hooks/usePreventLeave';
-import { ToastContainer, toast } from 'react-toastify';
+
 import 'react-toastify/dist/ReactToastify.css';
 
 interface locationType {
@@ -34,7 +36,6 @@ const Game = () => {
   }
 
   const { userList } = state;
-
   const [playerStateList, setPlayerStateList] = useState<PlayerState[]>([]);
   const [memoList, setMemoList] = useState<Memo[]>([]);
   const { chatList, sendChat, sendNightChat } = useChat();

--- a/packages/client/tsconfig.paths.json
+++ b/packages/client/tsconfig.paths.json
@@ -8,6 +8,7 @@
       "@hooks/*": ["src/hooks/*"],
       "@pages/*": ["src/pages/*"],
       "@constants/*": ["src/constants/*"],
+      "@contexts/*": ["src/contexts/*"],
       "@containers/*": ["src/containers/*"],
       "@components/*": ["src/components/*"]
     }

--- a/packages/server/sockets/ability.ts
+++ b/packages/server/sockets/ability.ts
@@ -1,6 +1,7 @@
 import { MAFIA_ABILITY, PUBLISH_VICTIM } from '@mafia/domain/constants/event';
 import { MafiaPick } from '@mafia/domain/types/game';
 import { Namespace, Socket } from 'socket.io';
+import GameStore from '../stores/GameStore';
 
 const mafiaPickList: MafiaPick[] = [];
 
@@ -12,9 +13,11 @@ const getRandomInt = (min: number, max: number) => {
 
 // 낮 됐다는 이벤트 받으면 호출할 함수
 const publishVictim = (namespace: Namespace) => {
+  const { name: roomId } = namespace;
   if (mafiaPickList.length > 0) {
     const randNum = getRandomInt(0, mafiaPickList.length);
     let { victim } = mafiaPickList[randNum];
+    GameStore.diePlayer(roomId, victim);
     namespace.emit(PUBLISH_VICTIM, victim);
     mafiaPickList.length = 0;
     victim = '';

--- a/packages/server/sockets/chat.ts
+++ b/packages/server/sockets/chat.ts
@@ -1,12 +1,25 @@
 import { MESSAGE, NIGHT_MESSAGE, PUBLISH_MESSAGE } from '@mafia/domain/constants/event';
 import { Message } from '@mafia/domain/types/chat';
 import { Socket } from 'socket.io';
+import GameStore from '../stores/GameStore';
+
+const ALIVE = false;
+const DEAD = true;
 
 const chatSocketInit = (socket: Socket) => {
   const { nsp: namespace } = socket;
+  const { name: roomId } = namespace;
 
   socket.on(MESSAGE, (chat: Message) => {
-    namespace.emit(PUBLISH_MESSAGE, chat);
+    const state = GameStore.getPlayerState(roomId, chat.userName);
+
+    if (state === undefined) return;
+    if (state === ALIVE) {
+      namespace.emit(PUBLISH_MESSAGE, chat);
+    }
+    if (state === DEAD) {
+      // TODO: 죽은 사람들 방으로 채팅 보내기
+    }
   });
 
   socket.on(NIGHT_MESSAGE, ({ msg, roomName }) => {

--- a/packages/server/sockets/vote.ts
+++ b/packages/server/sockets/vote.ts
@@ -1,4 +1,4 @@
-import { EXECUTION } from '@mafia/domain/constants/event';
+import { EXECUTION, PUBLISH_VOTE } from '@mafia/domain/constants/event';
 import { Namespace } from 'socket.io';
 import GameStore from '../stores/GameStore';
 
@@ -21,8 +21,11 @@ const publishExecution = (namespace: Namespace, roomId: string) => {
       maxCount = voteCount;
     }
   });
-  const excutedPlayer = { userName: maxCount === 0 || isSame ? undefined : maxPlayer };
-  namespace.emit(EXECUTION, excutedPlayer);
+  const excutedPlayer = maxCount === 0 || isSame ? undefined : maxPlayer;
+  GameStore.resetVote(roomId);
+  GameStore.diePlayer(roomId, excutedPlayer || '');
+  namespace.emit(EXECUTION, { userName: excutedPlayer });
+  namespace.emit(PUBLISH_VOTE, GameStore.getVoteInfos(roomId));
 };
 
 const startVoteTime = (namespace: Namespace, roomId: string, time: number) => {
@@ -31,7 +34,6 @@ const startVoteTime = (namespace: Namespace, roomId: string, time: number) => {
   setTimeout(() => {
     flag = false;
     publishExecution(namespace, roomId);
-    GameStore.resetVote(roomId);
   }, time);
 };
 

--- a/packages/server/stores/GameStore.ts
+++ b/packages/server/stores/GameStore.ts
@@ -25,6 +25,10 @@ class GameStore {
     return GameStore.instance[roomId];
   }
 
+  static set(roomId: string, gameInfo: GameInfo[]) {
+    GameStore.instance[roomId] = gameInfo;
+  }
+
   static resetGame(roomId: string) {
     GameStore.instance[roomId] = [];
   }
@@ -34,7 +38,11 @@ class GameStore {
   }
 
   static resetVote(roomId: string) {
-    GameStore.instance[roomId].map((gameInfo) => ({ ...gameInfo, voteFrom: [] }));
+    const resetVoteGameInfo: GameInfo[] = GameStore.get(roomId).map((gameInfo) => ({
+      ...gameInfo,
+      voteFrom: new Set(),
+    }));
+    GameStore.set(roomId, resetVoteGameInfo);
   }
 
   static voteUser(roomId: string, voteInfo: Vote): boolean {
@@ -58,6 +66,13 @@ class GameStore {
     const gameInfo = GameStore.get(roomId).find(({ userName }) => playerName === userName);
     if (!gameInfo) return gameInfo;
     return gameInfo.isDead;
+  }
+
+  static diePlayer(roomId: string, playerName: string) {
+    const deadPlayer = GameStore.get(roomId).find(({ userName }) => userName === playerName);
+    if (!deadPlayer) return;
+
+    deadPlayer.isDead = true;
   }
 
   static getDashBoard(roomId: string): DashBoard {

--- a/packages/server/stores/GameStore.ts
+++ b/packages/server/stores/GameStore.ts
@@ -21,6 +21,10 @@ class GameStore {
     return GameStore.instance;
   }
 
+  static get(roomId: string) {
+    return GameStore.instance[roomId];
+  }
+
   static resetGame(roomId: string) {
     GameStore.instance[roomId] = [];
   }
@@ -42,16 +46,18 @@ class GameStore {
     return true;
   }
 
-  static get(roomId: string) {
-    return GameStore.instance[roomId];
-  }
-
   static getVoteInfos(roomId: string): RoomVote[] {
     return GameStore.instance[roomId].map(({ userName, profileImg, voteFrom }) => ({
       userName,
       profileImg,
       voteCount: voteFrom.size,
     }));
+  }
+
+  static getPlayerState(roomId: string, playerName: string) {
+    const gameInfo = GameStore.get(roomId).find(({ userName }) => playerName === userName);
+    if (!gameInfo) return gameInfo;
+    return gameInfo.isDead;
   }
 
   static getDashBoard(roomId: string): DashBoard {


### PR DESCRIPTION
## 작업 목록

- [x]  사망시 채팅 비활성화
- [x]  사망시 투표 비활성화
- [x]  사망시 채팅 비활성화 테스트
- [x]  투표 끝나고 투표 초기화
<br/><br/>

## 설명
1. 사망시 채팅 비활성화
    - 서버쪽에서 확인 후, 죽은 플레이어라면 publish message를 안해주는 방식으로 구현
    - 추후에 죽은 플레이어라면 죽은 플레이어 방으로 넣어주고 그쪽으로 채팅 보내주면 될 듯
    
2. 사망시 투표 비활성화
    - 클라이언트에서 확인 후, 내가 죽은 상태라면 아무것도 안하고 반환하는 방식으로 구현

3. 투표 초기화
    - 서버쪽에서 투표 종료시 초기화 시켜주고 클라이언트로 publish vote 보내줘서 초기화 시킴

<br/><br/>
## Issue traker
- task issues: Resolves #99 
