### PR TITLE
[TASK] 유저 정보 조회 API 구현

### DIFF
--- a/packages/client/src/containers/RoomContainer.tsx
+++ b/packages/client/src/containers/RoomContainer.tsx
@@ -12,7 +12,7 @@ const RoomContainer = () => {
   const [roomList, setRoomList] = useState<RoomInfo[]>([]);
 
   const updateRoomList = async () => {
-    const url = `${process.env.REACT_APP_API_URL}/api/room`;
+    const url = `${process.env.REACT_APP_API_URL}/api/rooms`;
 
     const response = await fetch(url);
     const data = await response.json();

--- a/packages/server/api/user/index.ts
+++ b/packages/server/api/user/index.ts
@@ -4,5 +4,6 @@ import UserController from './user.controller';
 const userRouter = express.Router();
 
 userRouter.post('/update', UserController.updateUser);
+userRouter.get('/:userName', UserController.getUser);
 
 export default userRouter;

--- a/packages/server/api/user/index.ts
+++ b/packages/server/api/user/index.ts
@@ -3,7 +3,7 @@ import UserController from './user.controller';
 
 const userRouter = express.Router();
 
-userRouter.post('/update', UserController.updateUser);
+userRouter.post('/stat', UserController.updateUsersStat);
 userRouter.get('/:userName', UserController.getUser);
 
 export default userRouter;

--- a/packages/server/api/user/user.controller.ts
+++ b/packages/server/api/user/user.controller.ts
@@ -3,16 +3,16 @@ import { Request, Response } from 'express';
 import UserService from './user.service';
 
 const UserController = {
-  async updateUser(req: Request, res: Response) {
-    req.body.result.map(async (playerResult: PlayerResult) => {
-      try {
-        await UserService.update(playerResult);
-      } catch (error) {
-        console.log(error);
-        res.status(400).json({ error });
+  async updateUsersStat(req: Request, res: Response) {
+    await Promise.all(
+      req.body.result.map((playerResult: PlayerResult) => UserService.update(playerResult)),
+    ).catch((error) => {
+      console.log(error);
+      if (error instanceof Error) {
+        res.status(400).json({ error: error.message });
       }
     });
-    res.status(200).json({ result: 'OK' });
+    res.status(200).json({ result: 'Success' });
   },
 
   async getUser(req: Request, res: Response) {

--- a/packages/server/api/user/user.controller.ts
+++ b/packages/server/api/user/user.controller.ts
@@ -14,6 +14,24 @@ const UserController = {
     });
     res.status(200).json({ result: 'OK' });
   },
+
+  async getUser(req: Request, res: Response) {
+    if (!req.params.userName) {
+      res.status(400).json({
+        error: 'Request not include userName',
+      });
+      return;
+    }
+    try {
+      const stat = await UserService.findOne(req.params.userName);
+      res.status(200).json(stat);
+    } catch (error) {
+      console.log(error);
+      if (error instanceof Error) {
+        res.status(400).json({ error: error.message });
+      }
+    }
+  },
 };
 
 export default UserController;

--- a/packages/server/api/user/user.service.ts
+++ b/packages/server/api/user/user.service.ts
@@ -3,11 +3,11 @@ import User from '../../models/User';
 
 const UserService = {
   async findOne(userName: string) {
-    const exist = await User.findOne({ userName });
-    if (!exist) {
+    const user = await User.findOne({ userName });
+    if (!user) {
       throw Error('User Not Found');
     }
-    return { score: exist.score, playCnt: exist.playCnt, jobStat: exist.jobStat };
+    return user;
   },
   async findOneOrCreate(userName: string, profileImg: string) {
     const exist = await User.findOne({ userName });

--- a/packages/server/api/user/user.service.ts
+++ b/packages/server/api/user/user.service.ts
@@ -2,6 +2,13 @@ import { PlayerResult } from '@mafia/domain/types/game';
 import User from '../../models/User';
 
 const UserService = {
+  async findOne(userName: string) {
+    const exist = await User.findOne({ userName });
+    if (!exist) {
+      throw Error('User Not Found');
+    }
+    return { score: exist.score, playCnt: exist.playCnt, jobStat: exist.jobStat };
+  },
   async findOneOrCreate(userName: string, profileImg: string) {
     const exist = await User.findOne({ userName });
     if (!exist) {

--- a/packages/server/loaders/router.ts
+++ b/packages/server/loaders/router.ts
@@ -5,8 +5,8 @@ import userRouter from '../api/user';
 
 const routerLoader = (app: express.Application) => {
   app.use('/api/auth', authRouter);
-  app.use('/api/room', roomRouter);
-  app.use('/api/user', userRouter);
+  app.use('/api/rooms', roomRouter);
+  app.use('/api/users', userRouter);
 };
 
 export default routerLoader;

--- a/packages/server/sockets/game.ts
+++ b/packages/server/sockets/game.ts
@@ -25,7 +25,7 @@ const checkEnd = (roomId: string) => {
 
 const updateStats = (roomId: string) => {
   const result = getGameResult(roomId);
-  axios.post(`${apiURL}/user/update`, {
+  axios.post(`${apiURL}/users/stat`, {
     result,
   });
 };
@@ -51,7 +51,6 @@ const changeTurn = (
 const startTimer = (namespace: Namespace, roomId: string) => {
   let counter = 0;
   let isNight: boolean = false;
-
 
   namespace.emit(EVENT.TIMER, TIME.TURN - counter);
   namespace.emit(EVENT.TURN_CHANGE, isNight);


### PR DESCRIPTION
## 작업 목록

- [x] 사용자 한 명 정보 조회 API 구현 (`GET /api/users/:userName`)
- [x] API 경로 변경
- [x] 에러 경우 추가 처리 (사용자 없거나 필요 `params` 넘어오지 않을 경우)

## 설명
- API 경로 통일성 있도록 사용자 관련 `/api/users` 대기방 관련 `/api/rooms`로 시작하도록 변경했습니다
- 비동기로 인해 바로 response를 반환하던 로직 모든 비동기 처리 await하고 반환하도록 수정했습니다 (`POST /api/users/stat`)
- 초기에는 통계 정보만 반환하려고 했으나 정보량이 적고 숨겨야할 데이터가 아니라고 판단 -> 유저 전체 정보 반환하도록 구현
## Issue traker

- task issues: Resolves #122 
