### PR TITLE
[TASK] 게임 페이지에서 방 나가기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ yarn-error.log*
 
 # rest client
 *.rest
+*.http

--- a/packages/client/src/components/Modal/ConfirmModal.tsx
+++ b/packages/client/src/components/Modal/ConfirmModal.tsx
@@ -1,0 +1,66 @@
+import { FC } from 'react';
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
+
+import { primaryDark, white } from '@constants/index';
+import CustomModal from './CustomModal';
+
+type PropType = {
+  children: ReactJSXElement;
+  isOpen: boolean;
+  eventHandler: () => void;
+  closeModal: () => void;
+  onRequestClose: () => void;
+};
+
+export const ConfirmModal: FC<PropType> = ({
+  children,
+  isOpen,
+  onRequestClose,
+  eventHandler,
+  closeModal,
+}) => (
+  <CustomModal isOpen={isOpen} onRequestClose={onRequestClose} contentLabel="Confirm Modal">
+    <>
+      {children}
+      <div css={buttonPairStyle}>
+        <button type="button" className="prefer-button" onClick={eventHandler}>
+          예
+        </button>
+        <button type="button" className="cancel-button" onClick={closeModal}>
+          아니오
+        </button>
+      </div>
+    </>
+  </CustomModal>
+);
+
+const buttonPairStyle = css`
+  display: flex;
+  justify-content: space-around;
+
+  margin-top: 20px;
+
+  button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: transparent;
+    cursor: pointer;
+
+    padding: 5px 16px;
+    border-radius: 10px;
+  }
+
+  .prefer-button {
+    color: ${white};
+    background-color: ${primaryDark};
+  }
+
+  .cancel-button {
+    border: 1px solid ${primaryDark};
+  }
+`;
+
+export default ConfirmModal;

--- a/packages/client/src/components/Modal/CustomModal.tsx
+++ b/packages/client/src/components/Modal/CustomModal.tsx
@@ -1,0 +1,40 @@
+import Modal from 'react-modal';
+import { FC } from 'react';
+import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
+
+import { titleActive } from '@constants/index';
+
+Modal.setAppElement('#root');
+
+type PropType = {
+  children: ReactJSXElement;
+  isOpen: boolean;
+  onRequestClose: () => void;
+  contentLabel: string;
+};
+
+export const CustomModal: FC<PropType> = ({ children, isOpen, onRequestClose, contentLabel }) => (
+  <Modal
+    isOpen={isOpen}
+    onRequestClose={onRequestClose}
+    style={modalStyle}
+    contentLabel={contentLabel}
+  >
+    {children}
+  </Modal>
+);
+
+const modalStyle = {
+  content: {
+    top: '50%',
+    left: '50%',
+    right: 'auto',
+    bottom: 'auto',
+    padding: '3% 5%',
+    marginRight: '-50%',
+    color: `${titleActive}`,
+    transform: 'translate(-50%, -50%)',
+  },
+};
+
+export default CustomModal;

--- a/packages/client/src/components/Modal/NoticeModal.tsx
+++ b/packages/client/src/components/Modal/NoticeModal.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
+
+import CustomModal from './CustomModal';
+
+type PropType = {
+  children: ReactJSXElement;
+  isOpen: boolean;
+  onRequestClose: () => void;
+};
+
+export const NoticeModal: FC<PropType> = ({ children, isOpen, onRequestClose }) => (
+  <CustomModal isOpen={isOpen} onRequestClose={onRequestClose} contentLabel="Notice Modal">
+    {children}
+  </CustomModal>
+);
+
+export default NoticeModal;

--- a/packages/client/src/containers/LeftSideContainer.tsx
+++ b/packages/client/src/containers/LeftSideContainer.tsx
@@ -1,6 +1,8 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
+import Modal from 'react-modal';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
+import { useHistory } from 'react-router-dom';
 
 import { PlayerState } from '@mafia/domain/types/game';
 import { titleActive, white, grey1 } from '@constants/index';
@@ -21,6 +23,8 @@ type PropType = {
   myJob: string;
 };
 
+Modal.setAppElement('#root');
+
 const LeftSideContainer: FC<PropType> = ({
   playerStateList,
   playerList,
@@ -32,7 +36,10 @@ const LeftSideContainer: FC<PropType> = ({
   timer,
   myJob,
 }) => {
+  const history = useHistory();
   const { userInfo } = useUserInfo();
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+
   const handleClick = (userName: string) => {
     const myState = playerStateList.find(
       ({ userName: playerName }) => playerName === userInfo?.userName,
@@ -45,8 +52,34 @@ const LeftSideContainer: FC<PropType> = ({
     }
   };
 
+  const roomOutHandler = () => {
+    history.push('/rooms');
+  };
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
   return (
     <div css={leftSideContainerStyle}>
+      <Modal
+        isOpen={isModalOpen}
+        onRequestClose={closeModal}
+        style={modalStyle}
+        contentLabel="Confirm Modal"
+      >
+        <span>진행중인 게임을 포기하고 나가시겠습니까?</span>
+        <button type="button" onClick={roomOutHandler}>
+          예
+        </button>
+        <button type="button" onClick={closeModal}>
+          아니오
+        </button>
+      </Modal>
       <div css={Style}>
         <img
           src={isNight ? '/assets/images/moon.png' : '/assets/images/sun.png'}
@@ -65,7 +98,7 @@ const LeftSideContainer: FC<PropType> = ({
               icon={RoomOutIcon}
               size={ButtonSizeList.LARGE}
               theme={isNight ? ButtonThemeList.LIGHT : ButtonThemeList.DARK}
-              onClick={() => {}}
+              onClick={openModal}
             />
           </div>
         </div>
@@ -169,5 +202,17 @@ const abilityListStyle = css`
   width: 100%;
   gap: 16px 4%;
 `;
+
+const modalStyle = {
+  content: {
+    top: '50%',
+    left: '50%',
+    right: 'auto',
+    bottom: 'auto',
+    padding: '3% 5%',
+    marginRight: '-50%',
+    transform: 'translate(-50%, -50%)',
+  },
+};
 
 export default LeftSideContainer;

--- a/packages/client/src/containers/LeftSideContainer.tsx
+++ b/packages/client/src/containers/LeftSideContainer.tsx
@@ -1,13 +1,14 @@
-import React, { FC } from 'react';
-import Modal from 'react-modal';
+import { FC } from 'react';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import { useHistory } from 'react-router-dom';
 
+import useModal from '@hooks/useModal';
 import { PlayerState } from '@mafia/domain/types/game';
 import { titleActive, white, grey1 } from '@constants/index';
-import { AbilityButton, IconButton, ButtonSizeList, ButtonThemeList } from '@components/Button';
 import { SettingIcon, RoomOutIcon } from '@components/Icon';
+import ConfirmModal from '@components/Modal/ConfirmModal';
+import { AbilityButton, IconButton, ButtonSizeList, ButtonThemeList } from '@components/Button';
 import { RoomVote } from '@mafia/domain/types/vote';
 import { useUserInfo } from '@src/contexts/userInfo';
 
@@ -23,8 +24,6 @@ type PropType = {
   myJob: string;
 };
 
-Modal.setAppElement('#root');
-
 const LeftSideContainer: FC<PropType> = ({
   playerStateList,
   playerList,
@@ -38,7 +37,7 @@ const LeftSideContainer: FC<PropType> = ({
 }) => {
   const history = useHistory();
   const { userInfo } = useUserInfo();
-  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const { isModalOpen, openModal, closeModal } = useModal();
 
   const handleClick = (userName: string) => {
     const myState = playerStateList.find(
@@ -54,32 +53,19 @@ const LeftSideContainer: FC<PropType> = ({
 
   const roomOutHandler = () => {
     history.push('/rooms');
-  };
-
-  const openModal = () => {
-    setIsModalOpen(true);
-  };
-
-  const closeModal = () => {
-    setIsModalOpen(false);
+    closeModal();
   };
 
   return (
     <div css={leftSideContainerStyle}>
-      <Modal
+      <ConfirmModal
         isOpen={isModalOpen}
         onRequestClose={closeModal}
-        style={modalStyle}
-        contentLabel="Confirm Modal"
+        eventHandler={roomOutHandler}
+        closeModal={closeModal}
       >
-        <span>진행중인 게임을 포기하고 나가시겠습니까?</span>
-        <button type="button" onClick={roomOutHandler}>
-          예
-        </button>
-        <button type="button" onClick={closeModal}>
-          아니오
-        </button>
-      </Modal>
+        <p>진행중인 게임을 포기하고 나가시겠습니까?</p>
+      </ConfirmModal>
       <div css={Style}>
         <img
           src={isNight ? '/assets/images/moon.png' : '/assets/images/sun.png'}
@@ -202,17 +188,5 @@ const abilityListStyle = css`
   width: 100%;
   gap: 16px 4%;
 `;
-
-const modalStyle = {
-  content: {
-    top: '50%',
-    left: '50%',
-    right: 'auto',
-    bottom: 'auto',
-    padding: '3% 5%',
-    marginRight: '-50%',
-    transform: 'translate(-50%, -50%)',
-  },
-};
 
 export default LeftSideContainer;

--- a/packages/client/src/containers/RoomContainer.tsx
+++ b/packages/client/src/containers/RoomContainer.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import Modal from 'react-modal';
 import { Link } from 'react-router-dom';
 import { useQuery } from 'react-query';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import axios from 'axios';
-import { RoomCard } from '@src/components/Card';
-import { RoomInfo } from '@src/types';
 
-Modal.setAppElement('#root');
+import useModal from '@hooks/useModal';
+import { RoomInfo } from '@src/types';
+import { RoomCard } from '@components/Card';
+import NoticeModal from '@components/Modal/NoticeModal';
 
 const RoomContainer = () => {
-  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const { isModalOpen, openModal, closeModal } = useModal();
   const getRoomList = async () => {
     const url = `${process.env.REACT_APP_API_URL}/api/rooms`;
     const { data } = await axios.get(url);
@@ -21,11 +21,7 @@ const RoomContainer = () => {
   const enterRoomHandler = async (event: React.MouseEvent, roomStatus: string) => {
     if (roomStatus === 'ready') return;
     event.preventDefault();
-    setIsModalOpen(true);
-  };
-
-  const closeModal = () => {
-    setIsModalOpen(false);
+    openModal();
   };
 
   const { isLoading, data: roomList, error } = useQuery<RoomInfo[], Error>('rooms', getRoomList);
@@ -35,16 +31,15 @@ const RoomContainer = () => {
 
   return (
     <div css={roomContainerStyle}>
-      <Modal
-        isOpen={isModalOpen}
-        onRequestClose={closeModal}
-        style={modalStyle}
-        contentLabel="Alert Modal"
-      >
-        <span>이미 게임이 시작한 방입니다.</span>
-      </Modal>
+      <NoticeModal isOpen={isModalOpen} onRequestClose={closeModal}>
+        <p>이미 게임이 시작한 방입니다.</p>
+      </NoticeModal>
       {roomList!.map((roomInfo) => (
-        <Link to={{ pathname: '/waiting', search: roomInfo.roomId }} key={roomInfo.roomId} onClick={(event) => enterRoomHandler(event, roomInfo.status)}>
+        <Link
+          to={{ pathname: '/waiting', search: roomInfo.roomId }}
+          key={roomInfo.roomId}
+          onClick={(event) => enterRoomHandler(event, roomInfo.status)}
+        >
           <RoomCard roomInfo={roomInfo} />
         </Link>
       ))}
@@ -72,17 +67,5 @@ const roomContainerStyle = css`
     height: min-content;
   }
 `;
-
-const modalStyle = {
-  content: {
-    top: '50%',
-    left: '50%',
-    right: 'auto',
-    bottom: 'auto',
-    padding: '3% 5%',
-    marginRight: '-50%',
-    transform: 'translate(-50%, -50%)',
-  },
-};
 
 export default RoomContainer;

--- a/packages/client/src/hooks/useModal.ts
+++ b/packages/client/src/hooks/useModal.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useModal = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  return { isModalOpen, openModal, closeModal };
+};
+
+export default useModal;

--- a/packages/client/src/hooks/usePlayerState.ts
+++ b/packages/client/src/hooks/usePlayerState.ts
@@ -22,11 +22,13 @@ const usePlayerState = (initialValue: PlayerState[]) => {
   };
 
   useEffect(() => {
+    socketRef.current?.on(EVENT.EXIT, updatePlayerDead);
     socketRef.current?.on(EVENT.EXECUTION, updatePlayerDead);
     socketRef.current?.on(EVENT.PUBLISH_VICTIM, updatePlayerDead);
     socketRef.current?.on(EVENT.NOTICE_MAFIA, updatePlayerMafia);
 
     return () => {
+      socketRef.current?.off(EVENT.EXIT, updatePlayerDead);
       socketRef.current?.off(EVENT.EXECUTION, updatePlayerDead);
       socketRef.current?.off(EVENT.PUBLISH_VICTIM, updatePlayerDead);
       socketRef.current?.off(EVENT.NOTICE_MAFIA, updatePlayerMafia);

--- a/packages/domain/constants/event.ts
+++ b/packages/domain/constants/event.ts
@@ -1,4 +1,5 @@
 export const JOIN = 'join';
+export const EXIT = 'exit';
 export const READY = 'ready';
 export const PUBLISH_READY = 'publish ready';
 

--- a/packages/server/sockets/index.ts
+++ b/packages/server/sockets/index.ts
@@ -1,6 +1,7 @@
 import * as EVENT from '@mafia/domain/constants/event';
 import { PlayerInfo, User } from '@mafia/domain/types/user';
 import { Namespace, Socket } from 'socket.io';
+import GameStore from '../stores/GameStore';
 import RoomStore from '../stores/RoomStore';
 import { abilitySocketInit } from './ability';
 import chatSocketInit from './chat';
@@ -48,7 +49,9 @@ const socketInit = (namespace: Namespace): void => {
     socket.on('disconnect', () => {
       console.log(`👋 ${socket.id} exit from ${roomId}.`);
       RoomStore.removePlayer(roomId, socket.id);
+      const exitPlayer = GameStore.diePlayer(roomId, socket.id);
       socket.nsp.emit(EVENT.JOIN, RoomStore.get(roomId));
+      socket.nsp.emit(EVENT.EXIT, { userName: exitPlayer });
     });
 
     chatSocketInit(socket);

--- a/packages/server/stores/GameStore.ts
+++ b/packages/server/stores/GameStore.ts
@@ -80,17 +80,22 @@ class GameStore {
     return gameInfo.isDead;
   }
 
-  static diePlayer(roomId: string, playerName: string) {
-    const deadPlayer = GameStore.get(roomId).find(({ userName }) => userName === playerName);
+  static diePlayer(roomId: string, player: string) {
+    const gameInfo = GameStore.get(roomId);
+    if (!gameInfo) return;
+
+    const deadPlayer = gameInfo.find(
+      ({ userName, socketId }) => userName === player || socketId === player,
+    );
     if (!deadPlayer) return;
 
     deadPlayer.isDead = true;
+    return deadPlayer.userName;
   }
 
   static getDashBoard(roomId: string): DashBoard {
-    const mafia = GameStore.instance[roomId].filter(
-      ({ isDead, job }) => !isDead && job === 'mafia',
-    ).length;
+    const mafia = GameStore.instance[roomId].filter(({ isDead, job }) => !isDead && job === 'mafia')
+      .length;
     const citizen = GameStore.instance[roomId].filter(
       ({ isDead, job }) => !isDead && job !== 'mafia',
     ).length;


### PR DESCRIPTION
## 작업 목록

- [x]  방에서 나가면 `Rooms` 페이지로 보내주기
- [x]  방에서 나가면 서버쪽에서 클라이언트로 새로운 이벤트 전송 및 클라이언트에서 처리
- [x]  방에서 나가는 버튼을 눌렀을 때 한 번 더 확인해주는 `confirm` 모달 만들어줘서 보여주기
- [x]  모달 컴포넌트 리팩토링
- [x]  모달 스타일 예쁘게 적용
<br/><br/>

## 설명
1. 방에서 나가면 `Rooms` 페이지로 보내주기
    
    `history API` 사용해서 `Rooms` 페이지로 이동하게 했습니다!
    
2. 방에서 나가면 서버쪽에서 클라이언트로 죽었다고 알려주기
    - 서버쪽에서 클라이언트로 알려줄 이벤트 한 개 생성하기
    - `EXIT` 이벤트 생성해서 플레이어가 나가면 서버쪽에서 클라이언트로 `EXIT` 이벤트를 전송하고, 클라이언트에서는 해당 이벤트 받아서 사용자의 상태를 죽었다고 업데이트 시킴
    - 플레이어의 상태 업데이트 시키면 자동으로 화면상에 죽었다고 표시 됨
    
3. 방에서 나가는 버튼을 눌렀을 때 한 번 더 확인해주는 `confirm` 모달 만들어줘서 보여주기
    
    모달 만들어서 보여줬습니당!
    
![image](https://user-images.githubusercontent.com/48382813/142990823-c38ac574-6b33-45c8-b9d9-62c2764a01c7.png)
    
4. 모달 컴포넌트 생성해서 모아두기 (코드 리팩토링) & 모달 스타일 예쁘게 적용
    - 각 모달의 기본이 되는 `CustomModal` 컴포넌트를 생성
    - `CustomModal`을 사용하는 `ConfirmModal`, `NoticeModal`을 생성
    - 기존에 사용하던 Modal 들을 위에서 생성한 ConfirmModal, NoticeModal 로 대체
    
    **`ConfirmModal`**
    
![image](https://user-images.githubusercontent.com/48382813/142990858-5a874d60-4429-4cbe-b759-230300e5ce68.png)

    
    **`NoticeModal`**
    
![image](https://user-images.githubusercontent.com/48382813/142990901-ded47841-f223-4e1b-8bb0-d88b9c3cb821.png)
<br/><br/>

## Issue traker

- task issues: Resolves #157 
