### PR TITLE
[TASK] 죽은 사람끼리 채팅

### DIFF
--- a/packages/client/src/components/Message/ChatMsg.tsx
+++ b/packages/client/src/components/Message/ChatMsg.tsx
@@ -41,6 +41,13 @@ const msgContainerStyle = (isMyMsg: boolean) => css`
     max-width: 50px;
 
     span {
+      display: block;
+      overflow: hidden;
+      text-align: center;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      width: 50px;
       font-size: 10px;
       line-height: 10px;
     }

--- a/packages/client/src/components/Message/ChatMsg.tsx
+++ b/packages/client/src/components/Message/ChatMsg.tsx
@@ -2,22 +2,23 @@ import { FC } from 'react';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 
-import { primaryLight, primaryDark, white, titleActive } from '@constants/index';
+import { primaryLight, primaryDark, white, titleActive, grey1, grey2 } from '@constants/index';
 
 interface PropType {
   userName: string;
   profileImg: string;
   msg: string;
   isMyMsg: boolean;
+  isDead: boolean | undefined;
 }
 
-const ChatMsg: FC<PropType> = ({ userName, profileImg, msg, isMyMsg }) => (
+const ChatMsg: FC<PropType> = ({ userName, profileImg, msg, isMyMsg, isDead = false }) => (
   <div css={msgContainerStyle(isMyMsg)}>
     <div className="profile">
       <img css={profileImgStyle} src={profileImg} alt="profile" />
       <span>{userName}</span>
     </div>
-    <div css={msgStyle(isMyMsg)}>{msg}</div>
+    <div css={msgStyle(isMyMsg, isDead)}>{msg}</div>
   </div>
 );
 
@@ -54,14 +55,16 @@ const profileImgStyle = css`
   border: 2px solid ${titleActive};
 `;
 
-const msgStyle = (isMyMsg: boolean) => css`
+const msgStyle = (isMyMsg: boolean, isDead: boolean) => css`
   max-width: 65%;
   padding: 14px;
   font-size: 16px;
   line-height: 23px;
   border-radius: 20px;
-  color: ${isMyMsg ? white : titleActive};
-  background-color: ${isMyMsg ? primaryDark : primaryLight};
+  word-break: break-word;
+  color: ${isDead ? grey2 : isMyMsg ? white : titleActive};
+  border: ${isDead ? `1px solid ${isMyMsg ? primaryDark : grey1}` : 'none'};
+  background-color: ${isDead ? 'transparent' : isMyMsg ? primaryDark : primaryLight};
   border-top-right-radius: ${isMyMsg ? 0 : '20px'};
   border-bottom-left-radius: ${isMyMsg ? '20px' : 0};
 `;

--- a/packages/client/src/containers/ChatContainer.tsx
+++ b/packages/client/src/containers/ChatContainer.tsx
@@ -2,6 +2,7 @@ import React, { FC, useCallback, useState, useRef, useEffect } from 'react';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 
+import { PlayerState } from '@mafia/domain/types/game';
 import { Message } from '@mafia/domain/types/chat';
 import { Story } from '@src/types';
 import { useUserInfo } from '@src/contexts/userInfo';
@@ -11,6 +12,7 @@ import { IconButton, ButtonSizeList, ButtonThemeList } from '@components/Button'
 import { primaryLight, primaryDark, white, titleActive } from '@constants/index';
 
 interface PropType {
+  playerStateList: PlayerState[];
   chatList: (Message | Story)[];
   sendChat: any;
   sendNightChat: any;
@@ -21,7 +23,13 @@ function isStory(data: Message | Story): data is Story {
   return (data as Story).imgSrc !== undefined;
 }
 
-const ChatContainer: FC<PropType> = ({ chatList, sendChat, sendNightChat, isNight }) => {
+const ChatContainer: FC<PropType> = ({
+  playerStateList,
+  chatList,
+  sendChat,
+  sendNightChat,
+  isNight,
+}) => {
   const [inputValue, setInputValue] = useState('');
   const chatMsgsRef = useRef<HTMLDivElement>(null);
   const { userInfo } = useUserInfo();
@@ -75,6 +83,7 @@ const ChatContainer: FC<PropType> = ({ chatList, sendChat, sendNightChat, isNigh
               profileImg={el.profileImg}
               msg={el.msg}
               isMyMsg={userInfo?.userName === el.userName}
+              isDead={playerStateList.find(({ userName }) => userName === el.userName)?.isDead}
             />
           ),
         )}

--- a/packages/client/src/pages/Game/index.tsx
+++ b/packages/client/src/pages/Game/index.tsx
@@ -119,6 +119,7 @@ const Game = () => {
         myJob={myJob}
       />
       <ChatContainer
+        playerStateList={playerStateList}
         chatList={chatList}
         sendChat={sendChat}
         sendNightChat={sendNightChat}

--- a/packages/server/sockets/ability.ts
+++ b/packages/server/sockets/ability.ts
@@ -40,6 +40,11 @@ const publishVictim = (namespace: Namespace) => {
       storyName: StoryName.PUBLISH_SURVIVOR,
     });
   } else {
+    const deadSocketId = GameStore.getSocketId(roomId, currVictim);
+    if (deadSocketId) {
+      namespace.in(deadSocketId).socketsJoin('dead');
+    }
+
     namespace.emit(EVENT.PUBLISH_VICTIM, {
       userName: currVictim,
       storyName: StoryName.PUBLISH_VICTIM,

--- a/packages/server/sockets/chat.ts
+++ b/packages/server/sockets/chat.ts
@@ -16,9 +16,8 @@ const chatSocketInit = (socket: Socket) => {
     if (state === undefined) return;
     if (state === ALIVE) {
       namespace.emit(PUBLISH_MESSAGE, chat);
-    }
-    if (state === DEAD) {
-      // TODO: 죽은 사람들 방으로 채팅 보내기
+    } else if (state === DEAD) {
+      namespace.to('dead').emit(PUBLISH_MESSAGE, chat);
     }
   });
 

--- a/packages/server/sockets/vote.ts
+++ b/packages/server/sockets/vote.ts
@@ -24,8 +24,12 @@ const publishExecution = (namespace: Namespace, roomId: string) => {
       maxCount = voteCount;
     }
   });
-
   const excutedPlayer = maxCount === 0 || isSame ? undefined : maxPlayer;
+  const deadSocketId = GameStore.getSocketId(roomId, excutedPlayer);
+
+  if (deadSocketId) {
+    namespace.in(deadSocketId).socketsJoin('dead');
+  }
   GameStore.resetVote(roomId);
   GameStore.diePlayer(roomId, excutedPlayer || '');
   namespace.emit(EXECUTION, { userName: excutedPlayer, storyName: StoryName.EXECUTION });

--- a/packages/server/stores/GameStore.ts
+++ b/packages/server/stores/GameStore.ts
@@ -39,6 +39,11 @@ class GameStore {
     GameStore.instance[roomId] = gameInfoList;
   }
 
+  static getSocketId(roomId: string, playerName: string | undefined) {
+    if (!playerName) return undefined;
+    return GameStore.get(roomId).find(({ userName }) => userName === playerName)?.socketId;
+  }
+
   static resetGame(roomId: string) {
     GameStore.instance[roomId] = [];
   }
@@ -88,9 +93,8 @@ class GameStore {
   }
 
   static getDashBoard(roomId: string): DashBoard {
-    const mafia = GameStore.instance[roomId].filter(
-      ({ isDead, job }) => !isDead && job === 'mafia',
-    ).length;
+    const mafia = GameStore.instance[roomId].filter(({ isDead, job }) => !isDead && job === 'mafia')
+      .length;
     const citizen = GameStore.instance[roomId].filter(
       ({ isDead, job }) => !isDead && job !== 'mafia',
     ).length;


### PR DESCRIPTION
## 작업 목록
- [x]  서버쪽에서 죽은 사람 dead Room으로 넣어주기
- [x]  클라이언트에서 죽은 사람의 메세지 스타일 다르게 적용해주기
- [x]  서버쪽에서 메세지 요청을 받았을때 죽은사람 채팅이면 dead Room에 메세지 publish 해주기
- [x]  채팅 자잘한 오류 해결
<br/><br/>

## 설명
1. 서버쪽에서 죽은 사람 dead Room으로 넣어주기 & 서버쪽에서 메세지 요청을 받았을때 죽은사람 채팅이면 dead Room에 메세지 publish 해주기
    - GameStore에서 유저 네임을 받아 socketId를 반환해주는 함수 생성
    - 투표를 통해 죽은 사람과 마피아의 능력 사용으로 죽은 사람을 위 함수를 이용해 'dead' Room으로 넣어주고 채팅 메세지 요청을 받았을때 해당 유저가 죽은 플레이어라면 dead Room으로 publish 시켜줌
    
2. 클라이언트에서 죽은 사람의 메세지 스타일 다르게 적용해주기
    - 클라이언트에서는 죽은 사람의 메세지인지 판단하는 `isDead` 속성을 추가하고, 죽은 사람이라면 css 스타일을 다르게 설정해주었다!

1. 채팅 자잘한 오류 해결
    - 채팅 내용이 길어지면 메세지를 벗어나는 문제 해결
        - `word-break: break-word;` 를 사용
    - 닉네임이 길어지면 잘리는 문제 해결
        - github 을 보니깐 닉네임이 최대 39자였다. → 39자를 모두 지원하기에는 여러줄로 만들수도 없고 그렇다고 가로 길이를 무한정으로 길게할 수도 없었다.
        - 그래서 그냥 `ellpsis`를 사용해서 일정 가로 길이를 넘어가면 `...`으로 보이도록 처리
            
            → 더 좋은 방법이 있다면 공유부탁! (아마 동준 닉네임은 `...`으로 보일것으로 예상)
<br/><br/>

## Issue traker

- task issues: Resolves #167
