### PR TITLE
[TASK] 마피아 밤 채팅 & 죽은 사람 채팅 오류 해결

### DIFF
--- a/packages/client/src/components/Message/ChatMsg.tsx
+++ b/packages/client/src/components/Message/ChatMsg.tsx
@@ -2,7 +2,16 @@ import { FC } from 'react';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 
-import { primaryLight, primaryDark, white, titleActive, grey1, grey2 } from '@constants/index';
+import {
+  primaryLight,
+  primaryDark,
+  white,
+  titleActive,
+  grey1,
+  grey2,
+  mafiaMyMessage,
+  mafiaOtherMessage,
+} from '@constants/index';
 import { Message } from '@mafia/domain/types/chat';
 
 interface PropType {
@@ -16,7 +25,7 @@ const ChatMsg: FC<PropType> = ({ chat, isMyMsg }) => (
       <img css={profileImgStyle} src={chat.profileImg} alt="profile" />
       <span>{chat.userName}</span>
     </div>
-    <div css={msgStyle(isMyMsg, chat.isDead ?? false)}>{chat.msg}</div>
+    <div css={msgStyle(isMyMsg, chat.isDead, chat.isMafia)}>{chat.msg}</div>
   </div>
 );
 
@@ -60,18 +69,32 @@ const profileImgStyle = css`
   border: 2px solid ${titleActive};
 `;
 
-const msgStyle = (isMyMsg: boolean, isDead: boolean) => css`
+const msgStyle = (isMyMsg: boolean, isDead: boolean, isMafia: boolean) => css`
   max-width: 65%;
   padding: 14px;
   font-size: 16px;
   line-height: 23px;
   border-radius: 20px;
+
+  border: 'none';
   word-break: break-word;
-  color: ${isDead ? grey2 : isMyMsg ? white : titleActive};
-  border: ${isDead ? `1px solid ${isMyMsg ? primaryDark : grey1}` : 'none'};
-  background-color: ${isDead ? 'transparent' : isMyMsg ? primaryDark : primaryLight};
+  color: ${isMyMsg ? white : titleActive};
   border-top-right-radius: ${isMyMsg ? 0 : '20px'};
   border-bottom-left-radius: ${isMyMsg ? '20px' : 0};
+  background-color: ${isMyMsg ? primaryDark : primaryLight};
+
+  ${isMafia ? mafiaMsgStyle(isMyMsg) : ''}
+  ${isDead ? deadMsgStyle(isMyMsg) : ''}
+`;
+
+const deadMsgStyle = (isMyMsg: boolean = false) => css`
+  color: ${grey2};
+  border: 1px solid ${isMyMsg ? primaryDark : grey1};
+  background-color: transparent;
+`;
+
+const mafiaMsgStyle = (isMyMsg: boolean = false) => css`
+  background-color: ${isMyMsg ? mafiaMyMessage : mafiaOtherMessage};
 `;
 
 export default ChatMsg;

--- a/packages/client/src/components/Message/ChatMsg.tsx
+++ b/packages/client/src/components/Message/ChatMsg.tsx
@@ -3,22 +3,20 @@ import { FC } from 'react';
 import { css } from '@emotion/react';
 
 import { primaryLight, primaryDark, white, titleActive, grey1, grey2 } from '@constants/index';
+import { Message } from '@mafia/domain/types/chat';
 
 interface PropType {
-  userName: string;
-  profileImg: string;
-  msg: string;
+  chat: Message;
   isMyMsg: boolean;
-  isDead: boolean | undefined;
 }
 
-const ChatMsg: FC<PropType> = ({ userName, profileImg, msg, isMyMsg, isDead = false }) => (
+const ChatMsg: FC<PropType> = ({ chat, isMyMsg }) => (
   <div css={msgContainerStyle(isMyMsg)}>
     <div className="profile">
-      <img css={profileImgStyle} src={profileImg} alt="profile" />
-      <span>{userName}</span>
+      <img css={profileImgStyle} src={chat.profileImg} alt="profile" />
+      <span>{chat.userName}</span>
     </div>
-    <div css={msgStyle(isMyMsg, isDead)}>{msg}</div>
+    <div css={msgStyle(isMyMsg, chat.isDead ?? false)}>{chat.msg}</div>
   </div>
 );
 

--- a/packages/client/src/components/Message/StoryMsg.tsx
+++ b/packages/client/src/components/Message/StoryMsg.tsx
@@ -5,16 +5,17 @@ import { primaryDark, white } from '@src/constants';
 import { Image, ImageSizeList } from '@components/Image';
 import ExecuteAnimation from '@src/animation/ExecuteAnimation';
 import { SEC } from '@mafia/domain/constants/time';
+import { Story } from '@src/types';
 
 interface PropType {
-  msg: string;
-  imgSrc: string;
-  type?: string;
+  story: Story;
 }
 
-const StoryMsg: FC<PropType> = ({ msg, imgSrc, type }) => {
+const StoryMsg: FC<PropType> = ({ story }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [disabled, setDisabled] = useState(false);
+  const { msg, imgSrc, type } = story;
+
   const handleClick = () => {
     if (!videoRef.current) return;
     setDisabled(true);
@@ -24,6 +25,7 @@ const StoryMsg: FC<PropType> = ({ msg, imgSrc, type }) => {
       setDisabled(false);
     }, videoRef.current.duration * SEC);
   };
+
   return (
     <button type="button" css={storyMsgStyle} onClick={handleClick} disabled={disabled}>
       <div css={storyTextStyle}>{msg}</div>

--- a/packages/client/src/constants/colors.ts
+++ b/packages/client/src/constants/colors.ts
@@ -12,3 +12,5 @@ export const grey3 = '#D9DCE0';
 export const grey4 = '#F6F6F6';
 export const mafia = '#E95151';
 export const citizen = '#6DC436';
+export const mafiaMyMessage = '#C86262';
+export const mafiaOtherMessage = '#FAE4E4';

--- a/packages/client/src/containers/ChatContainer.tsx
+++ b/packages/client/src/containers/ChatContainer.tsx
@@ -13,7 +13,6 @@ import { primaryLight, primaryDark, white, titleActive } from '@constants/index'
 interface PropType {
   chatList: (Message | Story)[];
   sendChat: any;
-  sendNightChat: any;
   isNight: boolean;
 }
 
@@ -21,7 +20,7 @@ function isStory(data: Message | Story): data is Story {
   return (data as Story).imgSrc !== undefined;
 }
 
-const ChatContainer: FC<PropType> = ({ chatList, sendChat, sendNightChat, isNight }) => {
+const ChatContainer: FC<PropType> = ({ chatList, sendChat, isNight }) => {
   const [inputValue, setInputValue] = useState('');
   const chatMsgsRef = useRef<HTMLDivElement>(null);
   const { userInfo } = useUserInfo();
@@ -36,11 +35,8 @@ const ChatContainer: FC<PropType> = ({ chatList, sendChat, sendNightChat, isNigh
       msg: inputValue,
       profileImg: userInfo?.profileImg,
     };
-    if (isNight) {
-      sendNightChat(message, 'mafia');
-    } else {
-      sendChat(message);
-    }
+
+    sendChat(message, isNight);
     setInputValue('');
   }, [inputValue, isNight]);
 

--- a/packages/client/src/containers/ChatContainer.tsx
+++ b/packages/client/src/containers/ChatContainer.tsx
@@ -2,7 +2,6 @@ import React, { FC, useCallback, useState, useRef, useEffect } from 'react';
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 
-import { PlayerState } from '@mafia/domain/types/game';
 import { Message } from '@mafia/domain/types/chat';
 import { Story } from '@src/types';
 import { useUserInfo } from '@src/contexts/userInfo';
@@ -12,7 +11,6 @@ import { IconButton, ButtonSizeList, ButtonThemeList } from '@components/Button'
 import { primaryLight, primaryDark, white, titleActive } from '@constants/index';
 
 interface PropType {
-  playerStateList: PlayerState[];
   chatList: (Message | Story)[];
   sendChat: any;
   sendNightChat: any;
@@ -23,13 +21,7 @@ function isStory(data: Message | Story): data is Story {
   return (data as Story).imgSrc !== undefined;
 }
 
-const ChatContainer: FC<PropType> = ({
-  playerStateList,
-  chatList,
-  sendChat,
-  sendNightChat,
-  isNight,
-}) => {
+const ChatContainer: FC<PropType> = ({ chatList, sendChat, sendNightChat, isNight }) => {
   const [inputValue, setInputValue] = useState('');
   const chatMsgsRef = useRef<HTMLDivElement>(null);
   const { userInfo } = useUserInfo();
@@ -75,16 +67,9 @@ const ChatContainer: FC<PropType> = ({
       <div css={chatMsgsStyle} ref={chatMsgsRef}>
         {chatList.map((el) =>
           isStory(el) ? (
-            <StoryMsg key={el.id} msg={el.msg} imgSrc={el.imgSrc} type={el.type} />
+            <StoryMsg key={el.id} story={el} />
           ) : (
-            <ChatMsg
-              key={el.id}
-              userName={el.userName}
-              profileImg={el.profileImg}
-              msg={el.msg}
-              isMyMsg={userInfo?.userName === el.userName}
-              isDead={playerStateList.find(({ userName }) => userName === el.userName)?.isDead}
-            />
+            <ChatMsg key={el.id} chat={el} isMyMsg={userInfo?.userName === el.userName} />
           ),
         )}
       </div>

--- a/packages/client/src/hooks/useChat.ts
+++ b/packages/client/src/hooks/useChat.ts
@@ -72,17 +72,17 @@ const useChat = () => {
     };
   }, [socketRef.current]);
 
-  const sendChat = (msg: Message): void => {
+  const sendChat = (msg: Message, isNight: boolean): void => {
     if (!msg.msg) return;
-    socketRef.current?.emit(EVENT.MESSAGE, msg);
+    if (!isNight) {
+      socketRef.current?.emit(EVENT.MESSAGE, msg);
+      return;
+    }
+
+    socketRef.current?.emit(EVENT.NIGHT_MESSAGE, msg);
   };
 
-  const sendNightChat = (msg: Message, roomName: string): void => {
-    if (!msg.msg) return;
-    socketRef.current?.emit(EVENT.NIGHT_MESSAGE, { msg, roomName });
-  };
-
-  return { chatList, sendChat, sendNightChat };
+  return { chatList, sendChat };
 };
 
 export default useChat;

--- a/packages/client/src/pages/Game/index.tsx
+++ b/packages/client/src/pages/Game/index.tsx
@@ -130,7 +130,6 @@ const Game = () => {
         myJob={myJob}
       />
       <ChatContainer
-        playerStateList={playerStateList}
         chatList={chatList}
         sendChat={sendChat}
         sendNightChat={sendNightChat}

--- a/packages/client/src/pages/Game/index.tsx
+++ b/packages/client/src/pages/Game/index.tsx
@@ -55,7 +55,7 @@ const Game = () => {
 
   const { playerStateList } = usePlayerState(initPlayerState);
   const [memoList, setMemoList] = useState<Memo[]>([]);
-  const { chatList, sendChat, sendNightChat } = useChat();
+  const { chatList, sendChat } = useChat();
   const { voteList, voteUser, initVote } = useVote();
   const { timer, isNight, voteSec } = useTimer();
   const { myJob } = useGame();
@@ -129,12 +129,7 @@ const Game = () => {
         isNight={isNight}
         myJob={myJob}
       />
-      <ChatContainer
-        chatList={chatList}
-        sendChat={sendChat}
-        sendNightChat={sendNightChat}
-        isNight={isNight}
-      />
+      <ChatContainer chatList={chatList} sendChat={sendChat} isNight={isNight} />
       <RightSideContainer
         playerStateList={playerStateList}
         memoList={memoList}

--- a/packages/domain/types/chat.ts
+++ b/packages/domain/types/chat.ts
@@ -3,7 +3,8 @@ export interface Message {
   userName: string;
   profileImg: string;
   msg: string;
-  isDead?: boolean;
+  isDead: boolean;
+  isMafia: boolean;
 }
 
 export enum StoryName {

--- a/packages/domain/types/chat.ts
+++ b/packages/domain/types/chat.ts
@@ -1,8 +1,9 @@
 export interface Message {
   id: string;
   userName: string;
-  msg: string;
   profileImg: string;
+  msg: string;
+  isDead?: boolean;
 }
 
 export enum StoryName {

--- a/packages/server/sockets/ability.ts
+++ b/packages/server/sockets/ability.ts
@@ -4,66 +4,42 @@ import { PoliceInvestigation } from '@mafia/domain/types/game';
 import { Namespace, Socket } from 'socket.io';
 import GameStore from '../stores/GameStore';
 
-interface VictimData {
-  prevVictim: string;
-  currVictim: string;
-}
-
-const VictimStore: Record<string, VictimData> = {};
-const SurvivorStore: Record<string, string> = {};
-
-const resetVictimStore = (roomId: string) => {
-  VictimStore[roomId] = { prevVictim: '', currVictim: '' };
-};
-
-const updateVictim = (roomId: string) => {
-  const { prevVictim, currVictim } = VictimStore[roomId];
-  const newGameInfoList = GameStore.get(roomId).map((player) =>
-    // eslint-disable-next-line no-nested-ternary
-    player.userName === prevVictim
-      ? { ...player, isDead: false }
-      : player.userName === currVictim
-      ? { ...player, isDead: true }
-      : player,
-  );
-  GameStore.set(roomId, newGameInfoList);
-};
-
 const publishVictim = (namespace: Namespace) => {
   const roomId = namespace.name;
-  const { currVictim } = VictimStore[roomId];
-  const survivor = SurvivorStore[roomId];
+  const victim = GameStore.getVictim(roomId);
+  const survivor = GameStore.getSurvivor(roomId);
 
-  if (currVictim === survivor) {
-    namespace.emit(EVENT.PUBLISH_SURVIVOR, {
-      userName: survivor,
-      storyName: StoryName.PUBLISH_SURVIVOR,
-    });
-  } else {
-    const deadSocketId = GameStore.getSocketId(roomId, currVictim);
+  GameStore.resetSelected(roomId);
+
+  if (victim === '' || victim !== survivor) {
+    const deadSocketId = GameStore.getSocketId(roomId, victim);
     if (deadSocketId) {
+      GameStore.diePlayer(roomId, victim);
       namespace.in(deadSocketId).socketsJoin('dead');
     }
 
     namespace.emit(EVENT.PUBLISH_VICTIM, {
-      userName: currVictim,
+      userName: victim,
       storyName: StoryName.PUBLISH_VICTIM,
     });
+
+    return;
   }
-  resetVictimStore(roomId);
-  SurvivorStore[roomId] = '';
+
+  namespace.emit(EVENT.PUBLISH_SURVIVOR, {
+    userName: survivor,
+    storyName: StoryName.PUBLISH_SURVIVOR,
+  });
 };
 
 const abilitySocketInit = (socket: Socket) => {
   const { nsp: namespace } = socket;
   const roomId = namespace.name;
-  resetVictimStore(roomId);
+  GameStore.resetSelected(roomId);
 
-  socket.on(EVENT.MAFIA_ABILITY, (mafiaPick: string) => {
-    VictimStore[roomId].prevVictim = VictimStore[roomId].currVictim;
-    VictimStore[roomId].currVictim = mafiaPick;
-    namespace.to('mafia').emit(EVENT.MAFIA_ABILITY, VictimStore[roomId].currVictim);
-    updateVictim(roomId);
+  socket.on(EVENT.MAFIA_ABILITY, (userName: string) => {
+    GameStore.setVictim(roomId, userName);
+    namespace.to('mafia').emit(EVENT.MAFIA_ABILITY, GameStore.getVictim(roomId));
   });
 
   socket.on(EVENT.POLICE_ABILITY, (userName: string) => {
@@ -85,7 +61,7 @@ const abilitySocketInit = (socket: Socket) => {
   });
 
   socket.on(EVENT.DOCTOR_ABILITY, (userName: string) => {
-    SurvivorStore[roomId] = userName;
+    GameStore.setSurvivor(roomId, userName);
   });
 };
 

--- a/packages/server/sockets/chat.ts
+++ b/packages/server/sockets/chat.ts
@@ -15,9 +15,9 @@ const chatSocketInit = (socket: Socket) => {
 
     if (state === undefined) return;
     if (state === ALIVE) {
-      namespace.emit(PUBLISH_MESSAGE, chat);
+      namespace.emit(PUBLISH_MESSAGE, { ...chat, isDead: false });
     } else if (state === DEAD) {
-      namespace.to('dead').emit(PUBLISH_MESSAGE, chat);
+      namespace.to('dead').emit(PUBLISH_MESSAGE, { ...chat, isDead: true });
     }
   });
 

--- a/packages/server/sockets/chat.ts
+++ b/packages/server/sockets/chat.ts
@@ -15,15 +15,22 @@ const chatSocketInit = (socket: Socket) => {
 
     if (state === undefined) return;
     if (state === ALIVE) {
-      namespace.emit(PUBLISH_MESSAGE, { ...chat, isDead: false });
+      namespace.emit(PUBLISH_MESSAGE, { ...chat, isDead: false, isMafia: false });
     } else if (state === DEAD) {
-      namespace.to('dead').emit(PUBLISH_MESSAGE, { ...chat, isDead: true });
+      namespace.to('dead').emit(PUBLISH_MESSAGE, { ...chat, isDead: true, isMafia: false });
     }
   });
 
-  socket.on(NIGHT_MESSAGE, ({ msg, roomName }) => {
-    console.log('night message', msg);
-    namespace.to(roomName).emit(PUBLISH_MESSAGE, msg);
+  socket.on(NIGHT_MESSAGE, (chat: Message) => {
+    const state = GameStore.getPlayerState(roomId, chat.userName);
+    const job = GameStore.getPlayerJob(roomId, chat.userName);
+
+    if (state === undefined) return;
+    if (state === DEAD) {
+      namespace.to('dead').emit(PUBLISH_MESSAGE, { ...chat, isDead: true, isMafia: false });
+    } else if (state === ALIVE && job === 'mafia') {
+      namespace.to('mafia').emit(PUBLISH_MESSAGE, { ...chat, isDead: false, isMafia: true });
+    }
   });
 };
 

--- a/packages/server/sockets/game.ts
+++ b/packages/server/sockets/game.ts
@@ -40,6 +40,7 @@ const endGame = (
   clearInterval(interval);
   updateRoomStatus(roomId, 'ready');
   updateStats(roomId);
+  GameStore.resetGame(roomId);
 };
 
 const checkEnd = (roomId: string) => {
@@ -107,7 +108,7 @@ const assignJobs = (roomId: string) => {
   const jobs = JOB_ARR[RoomStore.get(roomId).length];
   const mixedJobs = shuffle(jobs);
 
-  if (jobs.length <= 0) throw Error('잘못된 인원입니다.');
+  if (jobs.length <= 0) throw Error('잘못된 인원입니다.'); // TODO: 4명 이하는 안되는걸로 바꾸고 Error handler 추가
   const gameInfoList = RoomStore.get(roomId).map(
     ({ userName, socketId, profileImg }, idx): GameInfo => ({
       socketId,

--- a/packages/server/stores/GameStore.ts
+++ b/packages/server/stores/GameStore.ts
@@ -5,6 +5,14 @@ interface GameStoreType {
   [roomId: string]: GameInfo[];
 }
 
+interface VictimStore {
+  [roomId: string]: string;
+}
+
+interface SurvivorStore {
+  [roomId: string]: string;
+}
+
 interface DashBoard {
   mafia: number;
   citizen: number;
@@ -12,6 +20,8 @@ interface DashBoard {
 
 class GameStore {
   static instance: GameStoreType = {};
+  static victims: VictimStore = {};
+  static survivors: SurvivorStore = {};
 
   private static canInvest: boolean = true;
 
@@ -39,17 +49,69 @@ class GameStore {
     GameStore.instance[roomId] = gameInfoList;
   }
 
+  static getVictim(roomId: string) {
+    return GameStore.victims[roomId];
+  }
+
+  static getSurvivor(roomId: string) {
+    return GameStore.survivors[roomId];
+  }
+
+  static setVictim(roomId: string, victim: string) {
+    GameStore.victims[roomId] = victim;
+  }
+
+  static setSurvivor(roomId: string, survivor: string) {
+    GameStore.survivors[roomId] = survivor;
+  }
+
   static getSocketId(roomId: string, playerName: string | undefined) {
     if (!playerName) return undefined;
-    return GameStore.get(roomId).find(({ userName }) => userName === playerName)?.socketId;
+    return GameStore.get(roomId)?.find(({ userName }) => userName === playerName)?.socketId;
+  }
+
+  static getPlayerInfo(roomId: string, playerName: string | undefined) {
+    if (!playerName) return undefined;
+    return GameStore.get(roomId)?.find(({ userName }) => playerName === userName);
+  }
+
+  static getVoteInfos(roomId: string): RoomVote[] {
+    return GameStore.instance[roomId].map(({ userName, profileImg, voteFrom }) => ({
+      userName,
+      profileImg,
+      voteCount: voteFrom.size,
+    }));
+  }
+
+  static getPlayerState(roomId: string, playerName: string) {
+    const playerInfo = GameStore.getPlayerInfo(roomId, playerName);
+    return playerInfo?.isDead;
+  }
+
+  static getPlayerJob(roomId: string, playerName: string) {
+    const playerInfo = GameStore.getPlayerInfo(roomId, playerName);
+    return playerInfo?.job;
+  }
+
+  static isSaved(roomId: string) {
+    return GameStore.victims[roomId] === GameStore.survivors[roomId];
   }
 
   static resetGame(roomId: string) {
     GameStore.instance[roomId] = [];
+    GameStore.victims[roomId] = '';
+    GameStore.survivors[roomId] = '';
   }
 
   static initGame(roomId: string, gameInfoList: GameInfo[] = []) {
     GameStore.instance[roomId] = gameInfoList;
+    GameStore.victims[roomId] = '';
+    GameStore.survivors[roomId] = '';
+  }
+
+  static resetSelected(roomId: string) {
+    GameStore.victims[roomId] = '';
+    GameStore.survivors[roomId] = '';
   }
 
   static resetVote(roomId: string) {
@@ -62,27 +124,13 @@ class GameStore {
 
   static voteUser(roomId: string, voteInfo: Vote): boolean {
     const { to, from } = voteInfo;
-    const votedUser = GameStore.get(roomId)?.find(({ userName }) => to === userName);
-    const votingUser = GameStore.get(roomId)?.find(({ userName }) => from === userName);
+    const votedUser = GameStore.getPlayerInfo(roomId, to);
+    const votingUser = GameStore.getPlayerInfo(roomId, from);
 
     if (!votedUser || !votingUser) return false;
     GameStore.get(roomId).forEach(({ voteFrom }) => voteFrom.delete(from));
     votedUser.voteFrom.add(from);
     return true;
-  }
-
-  static getVoteInfos(roomId: string): RoomVote[] {
-    return GameStore.instance[roomId].map(({ userName, profileImg, voteFrom }) => ({
-      userName,
-      profileImg,
-      voteCount: voteFrom.size,
-    }));
-  }
-
-  static getPlayerState(roomId: string, playerName: string) {
-    const gameInfo = GameStore.get(roomId).find(({ userName }) => playerName === userName);
-    if (!gameInfo) return gameInfo;
-    return gameInfo.isDead;
   }
 
   static diePlayer(roomId: string, player: string) {
@@ -99,10 +147,25 @@ class GameStore {
   }
 
   static getDashBoard(roomId: string): DashBoard {
-    const mafia = GameStore.instance[roomId].filter(({ isDead, job }) => !isDead && job === 'mafia')
-      .length;
+    const condition = ({ userName, isDead, job }: GameInfo, deadPlayer: string) => {
+      const mafiaCondition = !isDead && job === 'mafia';
+      const citizenCondition = !isDead && job !== 'mafia';
+
+      if (GameStore.isSaved(roomId)) {
+        return [mafiaCondition, citizenCondition];
+      }
+      return [
+        mafiaCondition && userName !== deadPlayer,
+        citizenCondition && userName !== deadPlayer,
+      ];
+    };
+
+    const deadPlayer = GameStore.getVictim(roomId);
+    const mafia = GameStore.instance[roomId].filter(
+      (gameInfo) => condition(gameInfo, deadPlayer)[0],
+    ).length;
     const citizen = GameStore.instance[roomId].filter(
-      ({ isDead, job }) => !isDead && job !== 'mafia',
+      (gameInfo) => condition(gameInfo, deadPlayer)[1],
     ).length;
 
     return { mafia, citizen };
@@ -114,6 +177,12 @@ class GameStore {
       job,
       result: (win === 'citizen' && job !== 'mafia') || win === job,
     }));
+  }
+
+  static removeGameInfos(roomId: string) {
+    delete GameStore.instance[roomId];
+    delete GameStore.victims[roomId];
+    delete GameStore.survivors[roomId];
   }
 }
 

--- a/packages/server/stores/RoomStore.ts
+++ b/packages/server/stores/RoomStore.ts
@@ -1,6 +1,7 @@
 import { PlayerInfo } from '@mafia/domain/types/user';
 import axios from 'axios';
 import { apiURL } from '../config/url.config.json';
+import GameStore from './GameStore';
 
 interface RoomStoreType {
   [roomId: string]: PlayerInfo[];
@@ -42,6 +43,7 @@ class RoomStore {
     );
 
     if (RoomStore.instance[roomId].length <= 0) {
+      GameStore.removeGameInfos(roomId);
       RoomStore.removeRoom(roomId);
       await axios.put(`${apiURL}/rooms`, {
         roomId: roomId.split('/')[1],


### PR DESCRIPTION
## 작업 목록

- [x]  죽기 전에 보낸 메세지 죽으면 죽은사람 채팅처럼 바뀌어버리는 문제 해결
- [x]  밤에 마피아끼리 채팅
- [x]  죽은사람 메세지 마피아에게 가는 문제 해결
- [x]  밤에 마피아끼리 채팅시 메세지 스타일 수정
- [x]  마피아가 밤에 죽이지 않을때 스토리카드 안나옴 문제 해결
<br/><br/>

## 설명
1. 죽기 전에 보낸 메세지가 죽은후에 전부 죽은사람 채팅처럼 바뀌어버리는 문제 해결
    
    메세지 자체 속성으로 `isDead` 속성 추가해서 해결!
    
2. 밤에 마피아끼리 채팅 & 죽은사람 메세지 마피아에게 가는 문제 해결
    - 메세지 자체 속성에 `isMafia` 속성 추가
    - 낮채팅, 밤 채팅 함수 하나로 (`sendChat`) 통일
    - 
    
3. 밤에 마피아끼리 채팅시 메세지 스타일 수정
    
    밤에 마피아끼리 채팅은 빨간 메세지로 스타일 수정
    
![image](https://user-images.githubusercontent.com/48382813/143388433-56bcfcb8-c25f-4188-8f74-24828275f976.png)

4. 마피아가 밤에 죽이지 않을때 스토리카드 안나옴 문제 해결
    - 원래 있던 `VictimStore`와 `SurvivorStore`를 `GameStore` 쪽으로 옮김
    - 마피아가 희생자를 고르지 않았을 경우 (`victim === ''`) 고려해서 이벤트 전송

<br/><br/>

## Issue traker

- task issues: Resolves #169 
